### PR TITLE
Implement temporary access check for /start

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -125,8 +125,13 @@ action_dispatcher: Optional[ActionDispatcher] = None
 
 @router.message(CommandStart())
 async def start_handler(message: types.Message, bot: Bot):
+    checking = await message.answer("Checking your access…")
     payload = build_payload_from_message(message, "command")
     response = await send_to_server(payload)
+    try:
+        await checking.delete()
+    except Exception:
+        logger.exception("Failed to delete checking message")
     if action_dispatcher:
         await action_dispatcher.dispatch(message, response)
 


### PR DESCRIPTION
## Summary
- show "Checking your access…" message when a user sends /start
- delete the temporary message after receiving the server reply

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6851d31392c08329ae3d0346da12a1d4