### PR TITLE
Implement session IDs and role menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a simple Telegram interface bot built with [Aiogram 3.x](https://docs.aiogram.dev/).
 It forwards all user interactions to a backend server and performs the actions
-returned by that server.
+returned by that server. Starting with phase 2.1 the bot includes the `chat_id`
+and a unique `session_id` with each request. If the server replies with a
+`user_role`, the bot shows the corresponding menu (admin, VIP or free).
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- track a session_id per chat and include chat_id in requests
- route users to admin, VIP, or free menus when server returns user_role
- document session and role handling in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6851d2f6cc78832988fd581355883c85